### PR TITLE
NullHandler implements Handler interface

### DIFF
--- a/log/handler.go
+++ b/log/handler.go
@@ -49,6 +49,6 @@ func (h *NullHandler) Write(b []byte) (n int, err error) {
 }
 
 // Close implements Handler interface
-func (h *NullHandler) Close() {
-
+func (h *NullHandler) Close() error {
+	return nil
 }


### PR DESCRIPTION
`NullHandler` previously is not a valid `Handler` as it doesn't return. This patch address that.